### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - typings install
 
 before_script:
+  - sleep 15
   - npm prune
 
 script:


### PR DESCRIPTION
Trying to fix the permanent fail from the unit tests. This is a fix like it is in the travis documentation.
This should delay the start of the unit tests and give the MongoDB sometime to start up