### PR TITLE
Replace some anti pattern code

### DIFF
--- a/Basic/service/user.ts
+++ b/Basic/service/user.ts
@@ -21,14 +21,7 @@ export class UserService {
   }
 
   public getUser(id: string): IUser {
-    let result: IUser;
-    this.userStorage.map(user => {
-      if (user.name === id) {
-        result = user;
-      }
-    });
-
-    return result;
+    return this.userStorage.find(user => user.name === id);
   }
 
   public newUser(user: IUser): IUser {
@@ -37,7 +30,7 @@ export class UserService {
   }
 
   public updateUser(id: string, user: IUser): IUser {
-    this.userStorage.map((entry, index) => {
+    this.userStorage.forEach((entry, index) => {
       if (entry.name === id) {
         this.userStorage[index] = user;
       }
@@ -47,14 +40,7 @@ export class UserService {
   }
 
   public deleteUser(id: string): string {
-    let updatedUser: IUser[] = [];
-    this.userStorage.map(user => {
-      if (user.name !== id) {
-        updatedUser.push(user);
-      }
-    });
-
-    this.userStorage = updatedUser;
+    this.userStorage = this.userStorage.filter(user => user.name !== id);
     return id;
   }
 }


### PR DESCRIPTION
- Replacing `.map` with `.forEach`

> Since map builds a new array, using it when you aren't using the returned array is an anti-pattern; use forEach or for-of instead.
> From [MDN ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) _When not to use map()_ section

- Replace _creating new array_ with `.filter`